### PR TITLE
docs: fix README tagline grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Agentic AI Shopping Assistant
 
+Experimenting with Agentic AI
+
 ## Introduction
 Personalized fashion shopping is great, but jumping between sites is slow and limits your options. It's a real time sink for shoppers seeking the perfect outfit.
 


### PR DESCRIPTION
## Summary
- correct README tagline to "Experimenting with Agentic AI"

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae8d71d70c8333ad0776db3f4caa32